### PR TITLE
Work History semesters instead of dates

### DIFF
--- a/app/Resources/views/participant_history/index.html.twig
+++ b/app/Resources/views/participant_history/index.html.twig
@@ -203,13 +203,11 @@
 											Avdelingen er slettet.
 										{% endif %}
 									</td>
-									<td> {{ wh.startDate|date ('d/m/y') }} </td>
+									<td> {{ wh.startSemester }} </td>
 													
-									{% if wh.endDate is not null %}
-										<td> {{ wh.endDate|date ('d/m/y') }}</td>
-									{% else %}
-										<td> - </td>
-									{% endif %}
+
+									<td> {{ wh.endSemester }}</td>
+
 													
 								</tr>
 												

--- a/app/Resources/views/profile/profile.html.twig
+++ b/app/Resources/views/profile/profile.html.twig
@@ -119,19 +119,26 @@
 										{% if assistantHistory is not empty %}
 										
 											<h3>Assistent historie</h3>
-											
+											<table style="table-layout: fixed; width:100%;">
+												<tr>
+													<th>Skole</th>
+													<th>Semester</th>
+												</tr>
 											{% for as in assistantHistory %}
-												
 												{% if as.semester is not null and as.school is not null %}
-													{{ as.getSemester.getName }}: {{ as.getSchool.getName }} {{ as.getSemester.getSemesterStartDate|date('d-m') }} - {{ as.getSemester.getSemesterEndDate|date('d-m') }} <br>
+												<tr>
+													<td>{{ as.getSchool.getName }}</td>
+													<td>{{ as.getSemester.getName }}</td>
+												</tr>
 												{% else %}
-													Semesteret og/eller skolen har blitt slettet.
+													<tr>
+														<td>Semesteret og/eller skolen har blitt slettet.</td>
+														<td>Semesteret og/eller skolen har blitt slettet.</td>
+													</tr>
 												{% endif %}
 											
 											{% endfor %}
-												
-											<hr>
-											
+											</table>
 										{% endif %}
 										
 									</div>
@@ -141,30 +148,44 @@
 										{% if workHistory is not empty %}
 										
 											<h3>Team historie</h3>
-												
+												<table style="width:100%; table-layout: fixed;">
+													<tr>
+														<th>Team</th>
+														<th>Stilling</th>
+														<th>Start</th>
+														<th>Slutt</th>
+													</tr>
 											{% for wh in workHistory %}
-												
+												<tr>
+													<td>
 												{% if wh.team is not null %}
-													{{ wh.team.name }} - 
+													{{ wh.team.name }}
 												{% else %}
 													Teamet er slettet - 
 												{% endif %}
-												
+													</td>
+
+													<td>
 												{% if wh.position is not null %}
-													{{ wh.position.name }}:
+													{{ wh.position.name }}
 												{% else %}
-													Stillingen er fjernet :
+													Stillingen er fjernet
 												{% endif %}
-												
-												{{ wh.startDate|date ('Y-m-d') }}
-													
-												{% if wh.endDate is not null %}
-													- {{ wh.endDate|date ('Y-m-d') }}
+													</td>
+
+													<td>
+												{{ wh.startSemester }}
+													</td>
+
+													<td>
+												{% if wh.endSemester is not null %}
+													{{ wh.endSemester }}
 												{% endif %}
-													
-												<br>
+													</td>
+												</tr>
 												
 											{% endfor %}
+													</table>
 											
 										{% endif %}
 

--- a/app/Resources/views/profile/public_profile.html.twig
+++ b/app/Resources/views/profile/public_profile.html.twig
@@ -119,57 +119,78 @@
 								</div>
 									
 								<div class="small-12 medium-12 large-12 columns">
-											
+
 									{% if assistantHistory is not empty %}
-										
+
 										<h3>Assistent historie</h3>
-									
-										{% for as in assistantHistory %}
-											
-											{% if as.semester is not null and as.school is not null %}
-												{{ as.getSemester.getName }}: {{ as.getSchool.getName }} {{ as.getSemester.getSemesterStartDate|date('d-m') }} - {{ as.getSemester.getSemesterEndDate|date('d-m') }} <br>
-											{% else %}
-												Semesteret og/eller skolen har blitt slettet.
-											{% endif %}
-											
-										{% endfor %}
-										
-										<hr>
-										
+										<table style="table-layout: fixed; width:100%;">
+											<tr>
+												<th>Skole</th>
+												<th>Semester</th>
+											</tr>
+											{% for as in assistantHistory %}
+												{% if as.semester is not null and as.school is not null %}
+													<tr>
+														<td>{{ as.getSchool.getName }}</td>
+														<td>{{ as.getSemester.getName }}</td>
+													</tr>
+												{% else %}
+													<tr>
+														<td>Semesteret og/eller skolen har blitt slettet.</td>
+														<td>Semesteret og/eller skolen har blitt slettet.</td>
+													</tr>
+												{% endif %}
+
+											{% endfor %}
+										</table>
 									{% endif %}
 									
 								</div>
 								
 								<div class="small-12 medium-12 large-12 columns">
-									
+
 									{% if workHistory is not empty %}
-									
+
 										<h3>Team historie</h3>
-									
-										{% for wh in workHistory %}
-											
-											{% if wh.team is not null %}
-												{{ wh.team.name }} -
-											{% else %}
-												Teamet er slettet - 
-											{% endif %}
-											
-											{% if wh.position is not null %}
-												{{ wh.position.name }}:   
-											{% else %}
-												Stillingen er fjernet:
-											{% endif %}
-											
-											{{ wh.startDate|date ('Y-m-d') }}
-													
-											{% if wh.endDate is not null %}
-												 - {{ wh.endDate|date ('Y-m-d') }}
-											{% endif %}
-													
-											<br>
-												
-										{% endfor %}
-									
+										<table style="width:100%; table-layout: fixed;">
+											<tr>
+												<th>Team</th>
+												<th>Stilling</th>
+												<th>Start</th>
+												<th>Slutt</th>
+											</tr>
+											{% for wh in workHistory %}
+												<tr>
+													<td>
+														{% if wh.team is not null %}
+															{{ wh.team.name }}
+														{% else %}
+															Teamet er slettet -
+														{% endif %}
+													</td>
+
+													<td>
+														{% if wh.position is not null %}
+															{{ wh.position.name }}
+														{% else %}
+															Stillingen er fjernet
+														{% endif %}
+													</td>
+
+													<td>
+														{{ wh.startSemester }}
+													</td>
+
+													<td>
+														{% if wh.endSemester is not null %}
+															{{ wh.endSemester }}
+														{% endif %}
+													</td>
+												</tr>
+
+											{% endfor %}
+										</table>
+
 									{% endif %}
 									
 								</div>

--- a/app/Resources/views/team_admin/create_work_history.html.twig
+++ b/app/Resources/views/team_admin/create_work_history.html.twig
@@ -25,18 +25,6 @@
 
 				</div>
 				
-				<div class="small-12 medium-12 large-6 columns">
-
-					<div class="panel callout radius">
-						
-						<h2> Format </h2>
-						Brukt formatet yyyy-MM-dd HH:mm:ss <br/>
-						Eksempel: 2015-10-03 10:30:00 <br/>
-						
-					</div>
-
-				</div>
-				
 			</div>
 						
 						

--- a/app/Resources/views/team_admin/specific_team.html.twig
+++ b/app/Resources/views/team_admin/specific_team.html.twig
@@ -113,12 +113,12 @@
 								{% endif %}
 								
 								</td>
-								<td> {{ wh.startDate|date('Y-m-d') }} <br> Kl. {{wh.startDate|date('H-m-s') }}</td>
+								<td> {{ wh.startSemester }} </td>
 								
-								{% if wh.endDate is null %}
-									<td>{{ wh.endDate | default("-") }} </td>
+								{% if wh.endSemester is null %}
+									<td>{{ wh.endSemester | default("-") }} </td>
 								{% else %}
-									<td> {{ wh.endDate|date('Y-m-d') }} <br> Kl. {{wh.endDate|date('H-m-s') }}</td>
+									<td> {{ wh.endSemester }} </td>
 								{% endif %}
 								
 								{% if is_granted('ROLE_SUPER_ADMIN') %}

--- a/src/AppBundle/Entity/WorkHistory.php
+++ b/src/AppBundle/Entity/WorkHistory.php
@@ -24,16 +24,16 @@ class WorkHistory {
 	 * @ORM\JoinColumn(onDelete="SET NULL")
      **/
     protected $user;
-	
-	/**
-     * @ORM\Column(type="datetime")
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Semester")
      */
-    protected $startDate;
-	
-	/**
-     * @ORM\Column(type="datetime", nullable=true)
+    protected $startSemester;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Semester")
      */
-    protected $endDate;
+    protected $endSemester;
 
 	/**
      * @ORM\ManyToOne(targetEntity="Team")
@@ -177,5 +177,51 @@ class WorkHistory {
     public function getPosition()
     {
         return $this->position;
+    }
+
+    /**
+     * Set startSemester
+     *
+     * @param \AppBundle\Entity\Semester $startSemester
+     * @return WorkHistory
+     */
+    public function setStartSemester(\AppBundle\Entity\Semester $startSemester = null)
+    {
+        $this->startSemester = $startSemester;
+
+        return $this;
+    }
+
+    /**
+     * Get startSemester
+     *
+     * @return \AppBundle\Entity\Semester 
+     */
+    public function getStartSemester()
+    {
+        return $this->startSemester;
+    }
+
+    /**
+     * Set endSemester
+     *
+     * @param \AppBundle\Entity\Semester $endSemester
+     * @return WorkHistory
+     */
+    public function setEndSemester(\AppBundle\Entity\Semester $endSemester = null)
+    {
+        $this->endSemester = $endSemester;
+
+        return $this;
+    }
+
+    /**
+     * Get endSemester
+     *
+     * @return \AppBundle\Entity\Semester 
+     */
+    public function getEndSemester()
+    {
+        return $this->endSemester;
     }
 }

--- a/src/AppBundle/Form/Type/CreateWorkHistoryType.php
+++ b/src/AppBundle/Form/Type/CreateWorkHistoryType.php
@@ -41,22 +41,28 @@ class CreateWorkHistoryType extends AbstractType {
 					  ->orderBy('p.name', 'ASC');
 					}
 			))
-			->add('startDate', 'datetime', array(
-				'label' => 'Starttidspunkt',
-				'widget' => 'single_text',
-				'date_format' => 'yyyy-MM-dd  HH:mm:ss',
-				'attr' => array(
-					'placeholder' => 'yyyy-MM-dd HH:mm:ss',
-				),
+			->add('startSemester', 'entity', array(
+				'label' => 'Start semester',
+				'class' => 'AppBundle:Semester',
+				'query_builder' => function(EntityRepository $er ) {
+					return $er->createQueryBuilder('s')
+						->orderBy('s.name', 'ASC')
+						->join('s.department', 'd')
+						->where('d.id = ?1')
+						->setParameter(1, $this->departmentId);
+				}
 			))
-			->add('endDate', 'datetime', array(
-				'label' => 'Sluttidspunkt (Valgfritt)',
-				'widget' => 'single_text',
-				'date_format' => 'yyyy-MM-dd  HH:mm:ss',
-				'required' => false ,
-				'attr' => array(
-					'placeholder' => 'yyyy-MM-dd HH:mm:ss',
-				),
+			->add('endSemester', 'entity', array(
+				'label' => 'Slutt semester (Valgfritt)',
+				'class' => 'AppBundle:Semester',
+				'query_builder' => function(EntityRepository $er ) {
+					return $er->createQueryBuilder('s')
+						->orderBy('s.name', 'ASC')
+						->join('s.department', 'd')
+						->where('d.id = ?1')
+						->setParameter(1, $this->departmentId);
+				},
+				'required' => false
 			))
 			->add('save', 'submit', array(
 				'label' => 'Opprett',


### PR DESCRIPTION
Når brukere legges til et team velger man startsemester og sluttsemester isteden for startdato og sluttdato.
På profilene vises assistent- og teamhistorikk i tabeller med start- og sluttsemester.

startDate og endDate er erstattet med startSemester og endSemester i WorkHistory entitien.
Databaseskjemaet må derfor oppdateres.